### PR TITLE
Changed method names in AsseticBundle

### DIFF
--- a/DataCollector/AsseticDataCollector.php
+++ b/DataCollector/AsseticDataCollector.php
@@ -47,7 +47,7 @@ class AsseticDataCollector extends DataCollector
         	
         	foreach ($collection->all() as $asset)
         	{
-        		$assets[] = $asset->getSourceUrl();
+        		$assets[] = $asset->getSourcePath();
         	}
         	
         	foreach ($collection->getFilters() as $filter)
@@ -56,7 +56,7 @@ class AsseticDataCollector extends DataCollector
         	}
         	
         	$collections[$name] = array(
-        		'target'  => $collection->getTargetUrl(),
+        		'target'  => $collection->getTargetPath(),
         		'assets'  => $assets,
         		'filters' => $filters 
         	);


### PR DESCRIPTION
Some method names in the AsseticBundle were changed from getXxxxxUrl() to getXxxxxPath(). I renamed the methods to make the WebProfilerExtraBundle compatible with the latest version of Symfony2 (Beta2).
