### PR TITLE
Add twig template data collection

### DIFF
--- a/DataCollector/TwigDataCollector.php
+++ b/DataCollector/TwigDataCollector.php
@@ -84,6 +84,47 @@ class TwigDataCollector extends DataCollector
     }
 
     /**
+     * Collects data on the twig templates rendered
+     *
+     * @param mixed $name       The template name
+     * @param array $parameters The array of parameters passed to the template
+     */
+    public function collectTemplateData($name, $parameters)
+    {
+        $collectedParameters = array();
+        foreach ($parameters as $name => $value) {
+            $collectedParameters[$name] = in_array(gettype($value), array('object', 'resource'))
+                ? get_class($value)
+                : gettype($value);
+        }
+
+        $this->data['templates'][] = array(
+            'name' => $name,
+            'parameters' => $collectedParameters
+        );
+    }
+
+    /**
+     * Returns the amount of Templates
+     *
+     * @return int Amount of templates
+     */
+    public function getCountTemplates()
+    {
+        return count($this->getTemplates());
+    }
+
+    /**
+     * Returns the Twig templates information
+     *
+     * @return array Template information
+     */
+    public function getTemplates()
+    {
+        return $this->data['templates'];
+    }
+
+    /**
      * Returns the amount of Extensions
      *
      * @return integer Amount of Extensions

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -6,12 +6,21 @@
 
     <parameters>
         <parameter key="web_profiler_extra.data_collector.twig.class">Elao\WebProfilerExtraBundle\DataCollector\TwigDataCollector</parameter>
+        <parameter key="web_profiler_extra.templating.engine.twig.class">Elao\WebProfilerExtraBundle\TwigProfilerEngine</parameter>
     </parameters>
 
     <services>
         <service id="web_profiler_extra.data_collector.twig" class="%web_profiler_extra.data_collector.twig.class%" public="false">
             <tag name="data_collector" template="WebProfilerExtraBundle:Collector:twig" id="twig" />
             <argument type="service" id="twig" />
+        </service>
+
+        <service id="templating.engine.twig" class="%web_profiler_extra.templating.engine.twig.class%">
+            <argument type="service" id="twig" />
+            <argument type="service" id="templating.name_parser" />
+            <argument type="service" id="templating.locator" />
+            <argument type="service" id="templating.globals" />
+            <argument type="service" id="web_profiler_extra.data_collector.twig" />
         </service>
     </services>
 </container>

--- a/Resources/views/Collector/twig.html.twig
+++ b/Resources/views/Collector/twig.html.twig
@@ -13,6 +13,27 @@
 {% endblock %}
 
 {% block panel %}
+    <h2>Twig Templates</h2>
+    <table>
+        <tr>
+            <th>Template</th>
+            <th>Parameters</th>
+        </tr>
+        {% for template in collector.templates %}
+        <tr>
+            <th>{{ template.name }}</th>
+            <td>
+                {% for parameter, type in template.parameters %}
+                <code>
+                    {{ parameter }}: {{ type }}
+                </code>
+                {% if not loop.last %}<br />{% endif %}
+                {% endfor %}
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+    <br />
     <h2>Twig Extensions</h2>
     <table>
         <tr>

--- a/TwigProfilerEngine.php
+++ b/TwigProfilerEngine.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Elao\WebProfilerExtraBundle;
+
+use Symfony\Bundle\TwigBundle\TwigEngine;
+
+use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
+use Symfony\Component\Templating\TemplateNameParserInterface;
+use Symfony\Component\Config\FileLocatorInterface;
+
+use Elao\WebProfilerExtraBundle\DataCollector\TwigDataCollector;
+
+class TwigProfilerEngine extends TwigEngine
+{
+    protected $collector;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(\Twig_Environment $environment, TemplateNameParserInterface $parser, FileLocatorInterface $locator, GlobalVariables $globals = null, TwigDataCollector $collector)
+    {
+        parent::__construct($environment, $parser, $locator, $globals);
+
+        $this->collector = $collector;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render($name, array $parameters = array())
+    {
+        $this->collector->collectTemplateData($name, $parameters);
+
+        return parent::render($name, $parameters);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": ">=2.0,<2.2-dev"
+        "symfony/framework-bundle": ">=2.0,<2.2-dev",
+        "symfony/twig-bundle": ">=2.0,<2.2-dev"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
This work is based on [CoreSphere/TwigProfilerBundle](https://github.com/CoreSphere/), updated and extended. It collects twig template information and parameters and adds it to the data already provided by the Twig Profiler. It extends the twig engine service, so I have added the twig bundle to the list of dependencies.
