### PR TITLE
Allow for custom route classes

### DIFF
--- a/DataCollector/RoutingDataCollector.php
+++ b/DataCollector/RoutingDataCollector.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * RoutingDataCollector.
@@ -31,7 +31,7 @@ class RoutingDataCollector extends DataCollector
      *
      * @param Router $router The Router Object
      */
-    public function __construct(Router $router)
+    public function __construct(RouterInterface $router)
     {
         $this->router = $router;
     }


### PR DESCRIPTION
When using E.G the RouteExtraBundle from Symfony-cmf, the route class can be an instance of `Symfony\Cmf\Component\Routing\ChainRouter` instead of `Symfony\Component\Routing\Router`, which then throws an error, as the `RouteDataCollector` only expects an instance of `Symfony\Component\Routing\Router`
