### PR TITLE
fix circular reference

### DIFF
--- a/DataCollector/AsseticDataCollector.php
+++ b/DataCollector/AsseticDataCollector.php
@@ -9,7 +9,7 @@
 
 namespace Elao\WebProfilerExtraBundle\DataCollector;
 
-use Assetic\Factory\LazyAssetManager;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,16 +22,16 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  */
 class AsseticDataCollector extends DataCollector
 {
-    protected $assetManager;
+    protected $container;
 
     /**
      * Constructor for the Assetic Datacollector
      *
-     * @param LazyAssetManager $assetManager Assetic Assetmanager
+     * @param Container $contaier The service container
      */
-    public function __construct(LazyAssetManager $assetManager)
+    public function __construct(Container $container)
     {
-        $this->assetManager = $assetManager;
+        $this->container = $container;
     }
 
     /**
@@ -45,7 +45,7 @@ class AsseticDataCollector extends DataCollector
     {
         $collections = array();
 
-        foreach ($this->assetManager->getNames() as $name) {
+        foreach ($this->getAssetManager()->getNames() as $name) {
             $collection = $this->assetManager->get($name);
             $assets = array();
             $filters = array();
@@ -67,6 +67,18 @@ class AsseticDataCollector extends DataCollector
 
         $this->data['collections'] = $collections;
     }
+
+    /**
+     * Get the Assetic Assetic manager
+     *
+     * @return LazyAssetManager
+     */
+    protected function getAssetManager()
+    {
+        return $this->container->get('assetic.asset_manager');
+    }
+
+
     /**
      * Calculates the Collection Count
      *

--- a/DataCollector/TwigDataCollector.php
+++ b/DataCollector/TwigDataCollector.php
@@ -13,6 +13,7 @@ namespace Elao\WebProfilerExtraBundle\DataCollector;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\DependencyInjection\Container;
 
 /**
  * AsseticDataCollector.
@@ -21,16 +22,16 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class TwigDataCollector extends DataCollector
 {
-    private $twig;
+    private $container;
 
     /**
      * The Constructor for the Twig Datacollector
      *
-     * @param \Twig_Environment $twig Twig Enviroment
+     * @param Container the service container
      */
-    public function __construct(\Twig_Environment $twig)
+    public function __construct(Container $container)
     {
-        $this->twig = $twig;
+        $this->container = $container;
     }
 
     /**
@@ -47,7 +48,7 @@ class TwigDataCollector extends DataCollector
         $extensions = array();
         $functions = array();
 
-        foreach ($this->twig->getExtensions() as $extensionName => $extension) {
+        foreach ($this->getTwig()->getExtensions() as $extensionName => $extension) {
             $extensions[] = array(
                 'name' => $extensionName,
                 'class' => get_class($extension)
@@ -99,6 +100,16 @@ class TwigDataCollector extends DataCollector
         $this->data['tests'] = $tests;
         $this->data['filters'] = $filters;
         $this->data['functions'] = $functions;
+    }
+
+    /**
+     * Get Twig Environment
+     *
+     * @return \Twig_Environment
+     */
+    protected function getTwig()
+    {
+        return $this->container->get('twig');
     }
 
     /**

--- a/Resources/config/assetic.xml
+++ b/Resources/config/assetic.xml
@@ -10,7 +10,7 @@
 
     <services>
         <service id="web_profiler_extra.data_collector.assetic" class="%web_profiler_extra.data_collector.assetic.class%" public="false">
-            <argument type="service" id="assetic.asset_manager" />
+            <argument type="service" id="service_container" />
             <tag name="data_collector" template="WebProfilerExtraBundle:Collector:assetic" id="assetic" />
         </service>
     </services>

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -11,7 +11,7 @@
 
     <services>
         <service id="web_profiler_extra.data_collector.twig" class="%web_profiler_extra.data_collector.twig.class%" public="false">
-            <argument type="service" id="twig" />
+            <argument type="service" id="service_container" />
             <tag name="data_collector" template="WebProfilerExtraBundle:Collector:twig" id="twig" />
         </service>
 


### PR DESCRIPTION
After the last merge, we have a circular reference for 2 data collector

I'm using the last version of Symfony 2.2
