### PR TITLE
Fatal error when filter contains closure

### DIFF
--- a/DataCollector/TwigDataCollector.php
+++ b/DataCollector/TwigDataCollector.php
@@ -58,8 +58,9 @@ class TwigDataCollector extends DataCollector
             foreach ($extension->getFilters() as $filterName => $filter) {
                 if ($filter instanceof \Twig_FilterInterface) {
                     $call = $filter->compile();
-			  if(is_array($call) && is_callable($call)) 
-			     $call = 'Method '.$call[1].' of an object '.get_class($call[0]);
+                    if(is_array($call) && is_callable($call)) {
+                        $call = 'Method '.$call[1].' of an object '.get_class($call[0]);
+                    }
                 } else {
                     $call = $filter->getName();
                 }


### PR DESCRIPTION
The profiler serialize objects returned by DataCollectors, but PHP can't serialize Closures. So if on filter is a closure or an object containing closure, we end up with the following error : 

```
Fatal error: Uncaught exception 'Exception' with message 'Serialization of 'Closure' is not allowed' in ...
```

My pull request replace objects passed as callback by the string : "Method **method name** of an object **class name**"
