### PR TITLE
 DEPRECATED #62

### DIFF
--- a/DataCollector/RoutingDataCollector.php
+++ b/DataCollector/RoutingDataCollector.php
@@ -67,7 +67,7 @@ class RoutingDataCollector extends DataCollector
             $controller = isset($defaults['_controller']) ? $defaults['_controller'] : 'unknown';
             $routes[$routeName] = array(
                 'name' => $routeName,
-                'pattern' => $route->getPattern(),
+                'pattern' => $route->getPath(),
                 'controller' => $controller,
                 'method' => isset($requirements['_method']) ? $requirements['_method'] : 'ANY',
             );


### PR DESCRIPTION
 DEPRECATED #62

DEPRECATED - The Symfony\Component\Routing\Route::getPattern method is deprecated since version 2.2 and will be removed in 3.0. Use the getPath() method instead.

in File /vendor/elao/web-profiler-extra-bundle/DataCollector/RoutingDataCollector.php
Line 70
'pattern' => $route->getPattern(),