### PR TITLE
Load ContainerBundle only if collect method is called

### DIFF
--- a/DataCollector/ContainerDataCollector.php
+++ b/DataCollector/ContainerDataCollector.php
@@ -35,7 +35,7 @@ class ContainerDataCollector extends DataCollector
      * @var ContainerBuilder
      */
     protected $containerBuilder;
-    
+
     /**
      * Constructor for the Container Datacollector
      *
@@ -71,7 +71,7 @@ class ContainerDataCollector extends DataCollector
         $services = array();
 
         $this->loadContainerBuilder();
-        
+
         if ($this->containerBuilder !== false) {
             foreach ($this->containerBuilder->getParameterBag()->all() as $key => $value) {
                 $service = substr($key, 0, strpos($key, '.'));

--- a/DataCollector/ContainerDataCollector.php
+++ b/DataCollector/ContainerDataCollector.php
@@ -26,10 +26,16 @@ use Symfony\Component\Config\FileLocator;
  */
 class ContainerDataCollector extends DataCollector
 {
+    /**
+     * @var Kernel
+     */
     protected $kernel;
-    protected $container;
-    protected $containerBuilder;
 
+    /**
+     * @var ContainerBuilder
+     */
+    protected $containerBuilder;
+    
     /**
      * Constructor for the Container Datacollector
      *
@@ -39,8 +45,6 @@ class ContainerDataCollector extends DataCollector
     public function __construct(Kernel $kernel, $displayInWdt)
     {
         $this->kernel = $kernel;
-        $this->container = $kernel->getContainer();
-        $this->containerBuilder = $this->getContainerBuilder();
         $this->data['display_in_wdt'] = $displayInWdt;
     }
 
@@ -66,6 +70,8 @@ class ContainerDataCollector extends DataCollector
         $parameters = array();
         $services = array();
 
+        $this->loadContainerBuilder();
+        
         if ($this->containerBuilder !== false) {
             foreach ($this->containerBuilder->getParameterBag()->all() as $key => $value) {
                 $service = substr($key, 0, strpos($key, '.'));
@@ -143,23 +149,27 @@ class ContainerDataCollector extends DataCollector
      *
      * @author Ryan Weaver <ryan@thatsquality.com>
      *
-     * @return ContainerBuilder
      */
-    private function getContainerBuilder()
+    private function loadContainerBuilder()
     {
+        if ($this->containerBuilder !== null) {
+            return;
+        }
+        $container = $this->kernel->getContainer();
         if (!$this->getKernel()->isDebug()
-            || !$this->container->hasParameter('debug.container.dump')
-            || !file_exists($cachedFile = $this->container->getParameter('debug.container.dump'))
+            || !$container->hasParameter('debug.container.dump')
+            || !file_exists($cachedFile = $container->getParameter('debug.container.dump'))
         ) {
-            return false;
+            $this->containerBuilder = false;
+            return;
         }
 
-        $container = new ContainerBuilder();
+        $containerBuilder = new ContainerBuilder();
 
-        $loader = new XmlFileLoader($container, new FileLocator());
+        $loader = new XmlFileLoader($containerBuilder, new FileLocator());
         $loader->load($cachedFile);
 
-        return $container;
+        $this->containerBuilder = $containerBuilder;
     }
 
     /**


### PR DESCRIPTION
Lately we got the issue that calls through the AsseticController are quite slow, even though the profiler is (by default) disabled for the render method.
This change would fix this issue.

The profiler could get deactivated during a request, so we wouldn't need the overhead of loading the container bundle

