### PR TITLE
[#SymfonyConHackday2017] SF4 compatibility update

### DIFF
--- a/DataCollector/AsseticDataCollector.php
+++ b/DataCollector/AsseticDataCollector.php
@@ -70,6 +70,14 @@ class AsseticDataCollector extends DataCollector
     }
 
     /**
+     * Resets this data collector to its initial state.
+     */
+    public function reset()
+    {
+        $this->data = ['display_in_wdt' => $this->data['display_in_wdt']];
+    }
+
+    /**
      * Get the Assetic Assetic manager
      *
      * @return LazyAssetManager

--- a/DataCollector/ContainerDataCollector.php
+++ b/DataCollector/ContainerDataCollector.php
@@ -102,6 +102,14 @@ class ContainerDataCollector extends DataCollector
     }
 
     /**
+     * Resets this data collector to its initial state.
+     */
+    public function reset()
+    {
+        $this->data = ['display_in_wdt' => $this->data['display_in_wdt']];
+    }
+
+    /**
      * Returns the Parameters Information
      *
      * @return array Collection of Parameters

--- a/DataCollector/RoutingDataCollector.php
+++ b/DataCollector/RoutingDataCollector.php
@@ -79,6 +79,14 @@ class RoutingDataCollector extends DataCollector
     }
 
     /**
+     * Resets this data collector to its initial state.
+     */
+    public function reset()
+    {
+        $this->data = ['display_in_wdt' => $this->data['display_in_wdt']];
+    }
+
+    /**
      * Returns the Amount of Routes
      *
      * @return integer Amount of Routes

--- a/DataCollector/TwigDataCollector.php
+++ b/DataCollector/TwigDataCollector.php
@@ -118,6 +118,14 @@ class TwigDataCollector extends DataCollector
     }
 
     /**
+     * Resets this data collector to its initial state.
+     */
+    public function reset()
+    {
+        $this->data = ['display_in_wdt' => $this->data['display_in_wdt']];
+    }
+
+    /**
      * Get Twig Environment
      *
      * @return \Twig_Environment

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,9 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "~2.1|~3.0",
-        "symfony/twig-bundle": "~2.0|~3.0",
+        "symfony/framework-bundle": "~2.1|~3.0|~4.0",
+        "symfony/templating": "~2.0|~3.0|~4.0",
+        "symfony/twig-bundle": "~2.0|~3.0|~4.0",
         "twig/twig": "~1.12|~2.0"
     },
     "autoload": {


### PR DESCRIPTION
#SymfonyConHackday2017

Word of explanation: the `reset()` method implementation is required to comply with the new `DataCollectorInterface`.